### PR TITLE
Change cred strength value defs to vals

### DIFF
--- a/src/main/scala/uk/gov/hmrc/auth/core/model.scala
+++ b/src/main/scala/uk/gov/hmrc/auth/core/model.scala
@@ -69,9 +69,9 @@ case class CredentialStrength(strength: String) extends Predicate {
 
 object CredentialStrength {
 
-  def strong: String = "strong"
+  val strong: String = "strong"
 
-  def weak: String = "weak"
+  val weak: String = "weak"
 }
 
 case class EnrolmentIdentifier(key: String, value: String)


### PR DESCRIPTION
This change is required so match statements can use the credential strength values to match on i.e.

```
"" match {
  case CredentialStrength.strong => ""
  case CredentialStrength.weak => ""
}
```
This would not compile when they are `defs`, you with get a `stable identifier required` compile error