### PR TITLE
BDOG 1267 Allow for Play 2.8 and removing Play 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ target
 
 .cache
 .target
+
+.metals/
+.vscode/
+.bloop/
+metals.sbt

--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
  
 libraryDependencies += "uk.gov.hmrc" %% "auth-client" % "[INSERT-VERSION]"
 ```
-Note that this library is only available for Play 2.6.x through to Play 2.7.x. Play 2.8+ is not yet supported.
+Note that this library is only available for Play 2.6.x through to Play 2.8.x. No other play versions are supported.
 
 > N.B. Play 2.7 support requires major version 3 of `auth-client`. This major release also includes an upgrade of the 
 > underlying [`http-verbs`](https://github.com/hmrc/http-verbs) library to major version 10.  
+
+> N.B. Play 2.8 support requires major version 4 of `auth-client`. This major release also includes an upgrade of the 
+> underlying [`http-verbs`](https://github.com/hmrc/http-verbs) library to major version 13.  
 
 > Play < 2.5 is no longer supported. If you plan to use it in a microservice that is still using an older version of Play, then you will need to upgrade it first.
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,12 +26,11 @@ lazy val library = Project(libName, file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
     makePublicallyAvailableOnBintray := true,
-    majorVersion                     := 3
+    majorVersion                     := 4
   )
   .settings(
     name := libName,
-    scalaVersion        := "2.11.12",
-    crossScalaVersions  := Seq("2.11.12", "2.12.12"),
+    scalaVersion        := "2.12.12",
     libraryDependencies ++= BuildDependencies(),
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
@@ -43,4 +42,3 @@ lazy val library = Project(libName, file("."))
   .settings(ScoverageSettings())
   .settings(SilencerSettings())
   .settings(ScalariformSettings())
-  

--- a/project/BuildDependencies.scala
+++ b/project/BuildDependencies.scala
@@ -4,10 +4,10 @@ import sbt._
 private object BuildDependencies {
 
   val compile: Seq[ModuleID] = dependencies(
-    shared = Seq("com.iheart"  %% "ficus"              % "1.4.7"),
-    play26 = Seq("uk.gov.hmrc" %% "http-verbs-play-26" % "13.0.0-SNAPSHOT" % Provided),
-    play27 = Seq("uk.gov.hmrc" %% "http-verbs-play-27" % "13.0.0-SNAPSHOT" % Provided),
-    play28 = Seq("uk.gov.hmrc" %% "http-verbs-play-28" % "13.0.0-SNAPSHOT" % Provided)
+    shared = Seq("com.iheart"  %% "ficus"              % "1.4.7"  ),
+    play26 = Seq("uk.gov.hmrc" %% "http-verbs-play-26" % "13.0.0" ),
+    play27 = Seq("uk.gov.hmrc" %% "http-verbs-play-27" % "13.0.0" ),
+    play28 = Seq("uk.gov.hmrc" %% "http-verbs-play-28" % "13.0.0" )
   )
 
   val test: Seq[ModuleID] = dependencies(

--- a/project/BuildDependencies.scala
+++ b/project/BuildDependencies.scala
@@ -4,18 +4,23 @@ import sbt._
 private object BuildDependencies {
 
   val compile: Seq[ModuleID] = dependencies(
-    shared = Seq("com.iheart" %% "ficus" % "1.4.7"),
-    play26 = Seq("uk.gov.hmrc" %% "http-verbs-play-26" % "12.3.0" % Provided),
-    play27 = Seq("uk.gov.hmrc" %% "http-verbs-play-27" % "12.3.0" % Provided)
+    shared = Seq("com.iheart"  %% "ficus"              % "1.4.7"),
+    play26 = Seq("uk.gov.hmrc" %% "http-verbs-play-26" % "13.0.0-SNAPSHOT" % Provided),
+    play27 = Seq("uk.gov.hmrc" %% "http-verbs-play-27" % "13.0.0-SNAPSHOT" % Provided),
+    play28 = Seq("uk.gov.hmrc" %% "http-verbs-play-28" % "13.0.0-SNAPSHOT" % Provided)
   )
 
   val test: Seq[ModuleID] = dependencies(
-    shared = Seq("org.pegdown" % "pegdown" % "1.6.0" % Test,
-                 "org.mockito" % "mockito-core" % "2.10.0" % Test,
-                 "org.scalamock" %% "scalamock" % "4.4.0" % Test
-    ),
-    play26 = Seq("org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % Test),
-    play27 = Seq("org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test)
+    shared = Seq("org.scalamock"          %% "scalamock"          % "4.4.0"   % Test),
+    play26 = Seq("org.mockito"            %  "mockito-core"       % "2.10.0"  % Test,
+                 "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"   % Test,
+                 "org.pegdown"            %  "pegdown"            % "1.6.0"   % Test),
+    play27 = Seq("org.mockito"            %  "mockito-core"       % "2.10.0"  % Test,
+                 "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3"   % Test,
+                 "org.pegdown"            %  "pegdown"            % "1.6.0"   % Test),
+    play28 = Seq("com.vladsch.flexmark"   %  "flexmark-all"       % "0.35.10" % Test,
+                 "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0"   % Test,
+                 "org.scalatestplus"      %% "mockito-3-4"        % "3.2.2.0" % Test)
   )
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,17 +1,9 @@
-resolvers += Resolver.url("hmrc-sbt-plugin-releases",
-  url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
+resolvers += Resolver.bintrayIvyRepo("hmrc", "sbt-plugin-releases")
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.13.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "1.2.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
-
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
+addSbtPlugin("uk.gov.hmrc"     % "sbt-auto-build"             % "2.13.0" )
+addSbtPlugin("uk.gov.hmrc"     % "sbt-git-versioning"         % "2.2.0"  )
+addSbtPlugin("uk.gov.hmrc"     % "sbt-artifactory"            % "1.13.0" )
+addSbtPlugin("uk.gov.hmrc"     % "sbt-play-cross-compilation" % "2.0.0"  )
+addSbtPlugin("org.scoverage"   % "sbt-scoverage"              % "1.6.1"  )
+addSbtPlugin("org.scalariform" % "sbt-scalariform"            % "1.8.3"  )

--- a/src/test/scala/uk/gov/hmrc/auth/MockingConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/auth/MockingConnectorSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.auth
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito
 import org.scalatest.WordSpec
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, Enrolments}
@@ -27,6 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import org.scalatestplus.mockito.MockitoSugar
 
 class MockingConnectorSpec extends WordSpec with MockitoSugar {
 

--- a/src/test/scala/uk/gov/hmrc/auth/delegation/DelegatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/auth/delegation/DelegatorSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.auth.delegation
 
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.Results.Ok
 import play.api.mvc.{RequestHeader, Result}

--- a/src/test/scala/uk/gov/hmrc/auth/otac/OtacAuthConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/auth/otac/OtacAuthConnectorSpec.scala
@@ -35,9 +35,9 @@ class OtacAuthConnectorSpec extends UnitSpec with MockFactory {
 
   def configureHttpStub(response: Future[HttpResponse]): Unit = {
     (stubbedCoreGet.GET[HttpResponse](
-      _: String)(
+      _: String, _: Seq[(String, String)], _: Seq[(String, String)])(
         _: HttpReads[HttpResponse], _: HeaderCarrier, _: ExecutionContext))
-      .when(mySerivceUrl + s"/authorise/read/$serviceName", *, *, *)
+      .when(mySerivceUrl + s"/authorise/read/$serviceName", *, *, *, *, *)
       .returns(response)
     ()
   }

--- a/src/test/scala/uk/gov/hmrc/auth/otac/OtacAuthorisationFunctionsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/auth/otac/OtacAuthorisationFunctionsSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.auth.otac
 
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.auth.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 


### PR DESCRIPTION
Updated scala, sbt and *sbt-play-cross-compilation* to allow for Play 2.8 and remove Play 2.5 builds.