### PR TITLE
BDOG-2803 Add Play 2.9

### DIFF
--- a/auth-client/src/main/scala/uk/gov/uk/hmrc/auth/AuthClientHasMoved.scala
+++ b/auth-client/src/main/scala/uk/gov/uk/hmrc/auth/AuthClientHasMoved.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.auth
+
+/**
+ * auth-client has been replaced with auth-client-play-xx.
+ * See [uk.gov.hmrc.auth.core.AuthorisedFunctions]
+ */
+private class AuthClientHasMoved

--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,14 @@ ThisBuild / scalacOptions    += "-Wconf:src=src_managed/.*:s" // silence all war
 lazy val library = (project in file("."))
   .settings(publish / skip := true)
   .aggregate(
+    authClient,
     authClientPlay28,
     authClientPlay29
   )
+
+// empty artefact, exists to ensure eviction of previous auth-client jar which has now moved into auth-client-play-28
+lazy val authClient = Project("auth-client", file("auth-client"))
+  .settings(crossScalaVersions := Seq(scala2_12, scala2_13))
 
 val sharedSources = Seq(
   Compile         / unmanagedSourceDirectories   += baseDirectory.value / s"../src-common/main/scala",
@@ -56,6 +61,7 @@ lazy val authClientPlay28 = Project("auth-client-play-28", file("auth-client-pla
   )
   .settings(ScoverageSettings())
   .settings(ScalariformSettings())
+  .dependsOn(authClient)
 
 lazy val authClientPlay29 = Project("auth-client-play-29", file("auth-client-play-29"))
   .enablePlugins(BuildInfoPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"     % "sbt-auto-build"      % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"     % "sbt-auto-build"      % "3.15.0")
 addSbtPlugin("org.scoverage"   % "sbt-scoverage"       % "2.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform"     % "1.8.3")

--- a/src-common/main/scala/uk/gov/hmrc/auth/clientversion/ClientVersion.scala
+++ b/src-common/main/scala/uk/gov/hmrc/auth/clientversion/ClientVersion.scala
@@ -21,7 +21,7 @@ package uk.gov.hmrc.auth.clientversion
  * (See https://github.com/sbt/sbt-buildinfo)
  */
 object ClientVersion {
-  private val versionRegex = raw"([0-9]+\.[0-9]+\.[0-9]+).+".r
+  private val versionRegex = raw"([0-9]+\.[0-9]+\.[0-9]+).*".r
 
   val version = BuildInfo.version match {
     case versionRegex(version) => version


### PR DESCRIPTION
- ClientVersion regex needs updating for final (non-snapshot) release after dropping the `-play-xx` suffix in the version.
- Adds an empty auth-client to evict the old artefact if it is still present in the dependency tree.